### PR TITLE
Add setup scala to workflow

### DIFF
--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -15,13 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 8 #build on JDK 8 for maximum compatibility
-          cache: sbt
-
+      - uses: guardian/setup-scala@v1
       - name: Run tests
         env:
           SBT_JUNIT_OUTPUT: ./junit-tests

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-8.432.06.1


### PR DESCRIPTION
Make the following changes in order to make sbt available:
- adds `setup-scala` to workflow
- creates `.tool-versions` to define the Java version

Note that this is built on JDK 8 for maximum compatibility

Workflow runs successfully on this branch
